### PR TITLE
Https 적용

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
-const { http, https } = require('./src/app');
+const { http, app } = require('./src/app');
+const HTTPS = require('https');
+const fs = require('fs');
 require('dotenv').config();
 require('./src/socket');
 require('./src/game/game-socket');
@@ -15,19 +17,23 @@ try {
 
 mongodb();
 
-try {
-    if (process.env.NODE_ENV === 'production') {
-        https.listen(process.env.PORT, () => {
-            console.log(`HTTPS SERVER CONNECTED, PORT :: ${process.env.PORT}}`);
+// 운영 환경일때만 적용
+if (process.env.NODE_ENV == 'production') {
+    try {
+        const option = {
+            ca: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/fullchain.pem`),
+            key: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/privkey.pem`),
+            cert: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/cert.pem`),
+        };
+
+        HTTPS.createServer(option, app).listen(3000, () => {
+            console.log('HTTPS 서버가 실행되었습니다. 포트 :: ' + process.env.PORT);
         });
-    } else {
-        http.listen(process.env.PORT, () => {
-            console.log(`HTTP SERVER CONNECTED, PORT :: ${process.env.PORT}}`);
-        });
+    } catch (error) {
+        console.log('HTTPS 서버가 실행되지 않습니다.');
     }
-} catch (e) {
-    console.log(e.message);
+} else {
     http.listen(process.env.PORT, () => {
-        console.log(`connected on HTTP, PORT :: ${process.env.PORT}}`);
+        console.log('HTTP 서버가 실행되었습니다. 포트 :: ' + process.env.PORT);
     });
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-const http = require('./src/app');
+const { http, https } = require('./src/app');
 require('dotenv').config();
 require('./src/socket');
 require('./src/game/game-socket');
@@ -15,6 +15,19 @@ try {
 
 mongodb();
 
-http.listen(process.env.PORT, () => {
-    console.log(`connect on http://127.0.0.1:${process.env.PORT}`);
-});
+try {
+    if (process.env.NODE_ENV === 'production') {
+        https.listen(process.env.PORT, () => {
+            console.log(`HTTPS SERVER CONNECTED, PORT :: ${process.env.PORT}}`);
+        });
+    } else {
+        http.listen(process.env.PORT, () => {
+            console.log(`HTTP SERVER CONNECTED, PORT :: ${process.env.PORT}}`);
+        });
+    }
+} catch (e) {
+    console.log(e.message);
+    http.listen(process.env.PORT, () => {
+        console.log(`connected on HTTP, PORT :: ${process.env.PORT}}`);
+    });
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,15 +1,25 @@
 const express = require('express');
 const { Server } = require('http');
+const HTTPS = require('https');
 const session = require('express-session');
 const passport = require('passport');
 const logger = require('morgan');
 const userRouter = require('./users/user-route');
 //const passportConfig = require('./middlewares/passport');
 const cors = require('cors');
+const fs = require('fs');
 
 require('dotenv').config();
 const app = express();
 const http = Server(app);
+
+const options = {
+    ca: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/fullchain.pem`),
+    key: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/privkey.pem`),
+    cert: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/cert.pem`),
+};
+
+const https = HTTPS.createServer(options, app);
 
 // middlewares
 app.use(function (req, res, next) {
@@ -43,4 +53,4 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use('/', userRouter);
 
-module.exports = http;
+module.exports = { http, https };

--- a/src/app.js
+++ b/src/app.js
@@ -1,25 +1,16 @@
 const express = require('express');
 const { Server } = require('http');
-const HTTPS = require('https');
+// const HTTPS = require('https');
 const session = require('express-session');
 const passport = require('passport');
 const logger = require('morgan');
 const userRouter = require('./users/user-route');
 //const passportConfig = require('./middlewares/passport');
 const cors = require('cors');
-const fs = require('fs');
 
 require('dotenv').config();
 const app = express();
 const http = Server(app);
-
-const options = {
-    ca: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/fullchain.pem`),
-    key: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/privkey.pem`),
-    cert: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/cert.pem`),
-};
-
-const https = HTTPS.createServer(options, app);
 
 // middlewares
 app.use(function (req, res, next) {
@@ -53,4 +44,4 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use('/', userRouter);
 
-module.exports = { http, https };
+module.exports = { http, app };

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,16 +1,24 @@
 const socketIo = require('socket.io');
-const { http, https } = require('./app');
+const { http, app } = require('./app');
+const HTTPS = require('https');
+const fs = require('fs');
 const cors = require('cors');
+require('dotenv').config();
 
 let io;
 if (process.env.NODE_ENV === 'production') {
-    io = socketIo(https, cors({ origin: '*' }));
-} else {
-    io = socketIo(http);
+    try {
+        const option = {
+            ca: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/fullchain.pem`),
+            key: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/privkey.pem`),
+            cert: fs.readFileSync(`/etc/letsencrypt/live/${process.env.DOMAIN}/cert.pem`),
+        };
+        const https = HTTPS.createServer(option, app);
+        io = socketIo(https, cors({ origin: '*' }));
+    } catch (e) {
+        console.log('io가 HTTPS 에서 실행되지 않습니다.');
+    }
 }
-
-io.on('connection', (socket) => {
-    console.log('socket.js connected', socket.id);
-});
+io = socketIo(http);
 
 module.exports = io;

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,7 +1,13 @@
 const socketIo = require('socket.io');
-const http = require('./app');
+const { http, https } = require('./app');
+const cors = require('cors');
 
-const io = socketIo(http);
+let io;
+if (process.env.NODE_ENV === 'production') {
+    io = socketIo(https, cors({ origin: '*' }));
+} else {
+    io = socketIo(http);
+}
 
 io.on('connection', (socket) => {
     console.log('socket.js connected', socket.id);


### PR DESCRIPTION
다행히 소켓 파일 코드 수정 없이 정상 동작 합니다!

배포할 서버 도메인 결정되면 .env에 DOMAIN 값 넣어주고, 배포서버에서 HTTPS 인증서 작업만 하면 됩니다! (소요시간 5분 정도)
현재 제가 개인 도메인으로 테스트 해봤고(콜백제외), 확인해보려면
https://minhyeongi.xyz로 시도 해보시면 됩니다. 

인증서가 없거나 NODE_ENV가 'production'이 아닐 경우 http로 동작하도록 했습니다. 
각자 로컬 작업 그대로 가능합니다. 

[EC2에서 Nginx로 HTTPS 적용하기](https://www.notion.so/ec2-Nginx-https-818abcea62584292ae6dc39f8f9a3d75)

@kimhsno1 @tastekim @yunjin5450 