### PR TITLE
ready 부분에서 spy 정보 및 제시어 전달 과정 추가, 그 외 추가 수정 내용.

### DIFF
--- a/src/game/game-provider.js
+++ b/src/game/game-provider.js
@@ -85,10 +85,6 @@ class GameProvider {
         return [roomCurrentCount, currNowVote];
     };
 
-    //방안에 있는 사람을 모아야 하는 로직을 만들어야함
-    //랜덤으로 스파이 유저를 뽑고, 그 방에 스파이 정보를 에밋을 받고
-    //스파이인유저랑 시민유저들 저장후 셔플
-
     collectUserNickname = async (roomNum, nickname) => {
         // 방에 참여 중인 유저 닉네임.
         await redis.rpush(`gameRoom${roomNum}Users`, nickname);
@@ -96,12 +92,8 @@ class GameProvider {
 
     // 스파이 랜덤 설정
     selectSpy = async (roomNum) => {
-        let getAllNickname = await redis.get(`gameRoom${roomNum}Users`, 0, -1);
+        let getAllNickname = await redis.lrange(`gameRoom${roomNum}Users`, 0, -1);
 
-        // let result = [];
-        // for (let i = 0; i < getAllNickname.length; i++) {
-        //     result.push(getAllNickname[i]);
-        // }
         const shuffleList = shuffle(getAllNickname);
         const spy = shuffleList.slice(-1);
 
@@ -152,11 +144,6 @@ class GameProvider {
         console.log(`${nickname} 님 발언을 시작해주세요.`);
         return randomStart;
     };
-    //찾아서 넣기
-    // await redis.del(`gameRoom${roomNum}Users`);
-    // await redis.del(`room${spyUser}`);
-    // await redis.del(`roomSpy${roomNum}`);
-    // await redis.del(`game${selectCategory}`);
 }
 
 module.exports = new GameProvider();

--- a/src/rooms/room-socket.js
+++ b/src/rooms/room-socket.js
@@ -1,6 +1,7 @@
 const lobby = require('../socket');
 const Room = require('../schemas/room');
 const redis = require('../redis');
+const GameProvider = require('../game/game-provider');
 
 const autoIncrease = function () {
     let a = 1;
@@ -76,7 +77,8 @@ lobby.on('connection', async (socket) => {
 
         const makedRoom = await Room.findOne({ _id: autoNum });
         const shwRoom = await Room.find({});
-        redis.set(`ready${autoNum}`, 0);
+        await redis.set(`ready${autoNum}`, 0);
+        await redis.set(`readyStatus${autoNum}`, '');
 
         socket.join(`/gameRoom${autoNum}`);
         console.log(makedRoom);
@@ -88,15 +90,16 @@ lobby.on('connection', async (socket) => {
     socket.on('enterRoom', async (roomNum) => {
         const udtRoom = await Room.findOne({ _id: roomNum });
 
-        if (udtRoom.currentCount <= 8) {
+        // 방에 들어와있는 인원이 최대 인원 수 보다 적고 roomStatus 가 false 상태일 때 입장 가능.
+        if (udtRoom.currentCount <= 8 && udtRoom.roomStatus === false) {
             await Room.findByIdAndUpdate({ _id: roomNum }, { $inc: { currentCount: 1 } });
 
-            const currntRoom = await Room.findOne({ _id: roomNum });
+            const currentRoom = await Room.findOne({ _id: roomNum });
 
             await socket.join(`/gameRoom${roomNum}`);
             console.log(socket.adapter.rooms);
-            console.log(currntRoom);
-            socket.emit('enterRoom', currntRoom);
+            console.log(currentRoom);
+            socket.emit('enterRoom', currentRoom);
         } else if (udtRoom.currentCount > 8) {
             console.log('풀방입니다.');
         }
@@ -105,30 +108,53 @@ lobby.on('connection', async (socket) => {
     // 게임 준비
     socket.on('ready', async (roomNum) => {
         const findRoom = await Room.findOne({ _id: roomNum });
+        // 처음 ready 버튼을 눌렀을 때.
         if (socket.isReady === undefined) {
             socket.isReady = 1;
-            redis.incr(`ready${roomNum}`);
-            Room.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
+            await redis.incr(`ready${roomNum}`);
+            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
         } else if (socket.isReady === 0) {
+            // ready 버튼 활성화 시킬 때.
             socket.isReady = 1;
-            redis.incr(`ready${roomNum}`, 1);
-            Room.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
+            await redis.incr(`ready${roomNum}`, 1);
+            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
             console.log('준비 완료 !');
         } else if (socket.isReady === 1) {
+            // ready 버튼 비활성화 시킬 때.
             socket.isReady = 0;
-            redis.decr(`ready${roomNum}`, 1);
-            Room.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, false);
+            await redis.decr(`ready${roomNum}`, 1);
+            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, false);
             console.log('준비 취소 !');
         }
         let readyCount = await redis.get(`ready${roomNum}`);
-        if (findRoom.currentCount == readyCount && findRoom.currentCount > 3) {
+        // 해당하는 방의 setTimeout 의 timer id 값 가져오기.
+        const readyStatus = await redis.get(`readyStatus${roomNum}`);
+        if (findRoom.currentCount === Number(readyCount) && findRoom.currentCount > 3) {
             console.log('게임시작 5초전!');
-            setTimeout(async () => {
+
+            // 특정 방의 timer identifier 를 저장, 나중에 누군가가 ready 가 취소됬을 때 해당하는 timer id 를 찾아서 멈추기 위해.
+            const readyStatus = setTimeout(async () => {
                 console.log('게임 시작 ! ');
-                lobby.to(`/gameRoom${roomNum}`).emit('gameStart');
+
+                // 스파이 랜덤 지정 후 게임 시작 전 emit.
+                const spyUser = await GameProvider.selectSpy(roomNum);
+                lobby.sockets.in(`/gameRoom${roomNum}`).emit('spyUser', spyUser);
+
+                // 카테고리 및 제시어 랜덤 지정 후 게임 시작과 같이 emit.
+                const gameData = await GameProvider.giveWord(roomNum);
+                lobby.sockets.in(`/gameRoom${roomNum}`).emit('gameStart', gameData);
+
+                // 게임방 진행 활성화. 다른 유저 입장 제한.
                 await Room.findByIdAndUpdate({ _id: roomNum }, { roomStatus: true });
                 await redis.del(`ready${roomNum}`);
+                await redis.del(`readyStatus${roomNum}`);
             }, 5000);
+
+            // 방의 timer id 저장.
+            await redis.set(`readyStatus${roomNum}`, readyStatus);
+        } else if (readyStatus !== '') {
+            // setTimeout 이 실행된 후 누군가 ready 를 취소했을 때 그 방의 setTimeout 정지시키기.
+            clearTimeout(readyStatus);
         }
     });
 });


### PR DESCRIPTION
# 수정 내용
## game-provider.is
1. 불필요한 주석 삭제.  

2. `redis.get`-> `redis.Irange` 로 수정: 0 부터 -1 까지의 배열 전체를 가져오는 로직이여 서 get 이 아닌 Irange 로 수정  

## room-socket.is
1. `const GameProvider = require(../game/game-provider')` 추가  

2. 방 생성 시 redis에 `readyStatus${autoNum}` 같이 생성: ready 부분에서 해당 방
의 setTimeout 의 timer identifier 를 저장하기 위한 용도.  

3. 게임방 입장 부분에 오탈자 수정: `currntRoom` -> `currentRoom`

4. 게임방 입장 조건 내용 추가: 현재 입장 인원이 8명 이하이면 입장 가능 조건에 게임 시작
상태인 `roomStatus`가  `false` 인 상태인 조건도 추가.  

5. 게임 준비 부분에 해당 방 전체에 emit 하는 부분 오탈자 수정: `lobby.socket.emit` 으로 해야하는데 `Room.sockets.emit` 으로 되어있어서 FE에서 args 들이 undefined 로 나오는 것 수정.  

6. 132번째 줄의 동등 연산자를 일치 연산자로 수정: redis는 int 값을 저장하지 못하기 때 문에 `readyCount`를 `Number`로 형변환해서 일치 연산자로 비교.  

7. 게임 시작을 알리는 `gameStart` 이벤트를 emit 하기 전에 게임에서 spy 역할과 사용
제시어를 같이 전달하는 로직 추가.  

8. setTimeout 실행 후 누군가 다시 ready 를 취소했을 때 해당 timer id를 찾아서 정지시키는 로직 추가.