### PR TITLE
Game/complete - ready 기능 마무리 및 게임 시작 전 스파이 / 제시어 전달

### DIFF
--- a/src/rooms/room-socket.js
+++ b/src/rooms/room-socket.js
@@ -112,18 +112,21 @@ lobby.on('connection', async (socket) => {
         if (socket.isReady === undefined) {
             socket.isReady = 1;
             await redis.incr(`ready${roomNum}`);
-            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
+            await redis.rpush(`gameRoom${roomNum}Users`, socket.nickname);
+            lobby.sockets.in(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
         } else if (socket.isReady === 0) {
             // ready 버튼 활성화 시킬 때.
             socket.isReady = 1;
             await redis.incr(`ready${roomNum}`);
-            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
+            await redis.rpush(`gameRoom${roomNum}Users`, socket.nickname);
+            lobby.sockets.in(`/gameRoom${roomNum}`).emit('ready', socket.nickname, true);
             console.log('준비 완료 !');
         } else if (socket.isReady === 1) {
             // ready 버튼 비활성화 시킬 때.
             socket.isReady = 0;
             await redis.decr(`ready${roomNum}`);
-            lobby.sockets.to(`/gameRoom${roomNum}`).emit('ready', socket.nickname, false);
+            await redis.lrem(`gameRoom${roomNum}Users`, 1, socket.nickname);
+            lobby.sockets.in(`/gameRoom${roomNum}`).emit('ready', socket.nickname, false);
             console.log('준비 취소 !');
         }
         let readyCount = await redis.get(`ready${roomNum}`);


### PR DESCRIPTION
# 수정내용
## game-provider.js
1. 불필요한 코드 삭제 및 redis 코드 수정: 배열을 추가하는 것이기 때문에 `set` -> `lpush`로 변경. 
2. shuffle 후 마지막 배열의 요소 꺼낼 때 메소드 수정: `slice` 로 꺼내면 마지막 요소가 배열형태로 꺼내져서 대신 `pop()`사용. 

## room-socket.js
1. redis 에 게임에 참가하는 유저들의 닉네임 저장하는 로직 추가: `lpush` 로 추가하고 준비하기를 취소할 땐 `lrem`으로 제거.