### PR TITLE
nowVote 이벤트에서 voteStatus 매개변수 추가

### DIFF
--- a/src/game/game-socket.js
+++ b/src/game/game-socket.js
@@ -47,15 +47,15 @@ game.on('connection', (socket) => {
     });
 
     // 게임 진행 중 스파이 투표 찬반 투표 실행.
-    socket.on('nowVote', async (roomNum) => {
-        if (socket.nowVote === undefined) {
-            socket.nowVote = true;
-        } else {
-            socket.nowVote ? (socket.nowVote = false) : (socket.nowVote = true);
-        }
+    socket.on('nowVote', async (roomNum, voteStatus) => {
+        // if (socket.nowVote === undefined) {
+        //     socket.nowVote = true;
+        // } else {
+        //     socket.nowVote ? (socket.nowVote = false) : (socket.nowVote = true);
+        // }
 
         // max -> 스파이를 제외한 정원 수, curr -> 현재 nowVote 를 누른 수.
-        const [max, curr] = await GameProvider.nowVote(roomNum, socket.nowVote);
+        const [max, curr] = await GameProvider.nowVote(roomNum, voteStatus);
         // if (max === curr) {
         //     // 바로 최종 스파이 투표로 진행.
         //     game.sockets.in(`/gameRoom${roomNum}`).emit('voteStart', curr);


### PR DESCRIPTION
# 수정내용
프론트에서 `nowVote` 이벤트 메세지로 emit 할 때 boolean 값도 같이 전달해줘서 `socket.nowVote` 대신 프론트에서 주는 값으로만 투표 참여 여부를 체크하는 방식으로 수정했습니다.
이유는 유저가 처음 참여하는 게임방에서는 `socket.nowVote`가 `undefined`로 지정이 되어 있어서 우리가 그 부분을 캐치하고 boolean 값을 넣어주는데 이 유저가 소켓을 유지한 상태로 다음 게임방으로 들어가면 그 순간 부터 `nowVote`라는 키값을 같고 있는 상태이기 때문에 `nowVote` 이벤트 메세지에서 첫 번째 `if` 문을 지나칠거고 전 게임방에서 갖고 있던 boolean 값이 기준이 되어버리기 때문에 꼬여버리게 되는 상황이 생깁니다.

```javascript
// 기존 코드
socket.on('nowVote', async (roomNum) => {
        if (socket.nowVote === undefined) { // 이 부분이 유저가 처음 게임에 참여할 때만 진행되고 그 다음 게임부턴 해당사항이 안됨.
            socket.nowVote = true;
        } else {
            socket.nowVote ? (socket.nowVote = false) : (socket.nowVote = true);
        }

        // max -> 스파이를 제외한 정원 수, curr -> 현재 nowVote 를 누른 수.
        const [max, curr] = await GameProvider.nowVote(roomNum, socket.nowVote);

// 수정 후
socket.on('nowVote', async (roomNum, voteStatus) => { // 프론트에서 주는 boolean 값을 그대로 사용.
        // if (socket.nowVote === undefined) { // 주석들은 마지막 때 싹 정리하겠습니다.
        //     socket.nowVote = true;
        // } else {
        //     socket.nowVote ? (socket.nowVote = false) : (socket.nowVote = true);
        // }

        // max -> 스파이를 제외한 정원 수, curr -> 현재 nowVote 를 누른 수.
        const [max, curr] = await GameProvider.nowVote(roomNum, voteStatus); // socket.nowVote 대신 voteStatus 사용.
```