### PR TITLE
room-socket.js에 setTimeout, ready 이벤트의 redis del 구문 삭제

### DIFF
--- a/src/rooms/room-socket.js
+++ b/src/rooms/room-socket.js
@@ -99,39 +99,28 @@ lobby.on('connection', async (socket) => {
             console.log(readyCount, '/', currentCount);
         }
         // 해당하는 방의 setTimeout 의 timer id 값 가져오기.
-        const readyStatus = await redis.get(`readyStatus${roomNum}`);
         readyCount = await redis.get(`ready${roomNum}`);
         if (currentCount === Number(readyCount) && currentCount > 3) {
             console.log('게임시작 5초전!');
 
             // 특정 방의 timer identifier 를 저장, 나중에 누군가가 ready 가 취소됬을 때 해당하는 timer id 를 찾아서 멈추기 위해.
-            const readyStatus = setTimeout(async () => {
-                console.log('게임 시작 ! ');
-                // 스파이 랜덤 지정 후 게임 시작 전 emit.
-                const spyUser = await GameProvider.selectSpy(roomNum);
-                lobby.sockets.in(`/gameRoom${roomNum}`).emit('spyUser', spyUser);
+            console.log('게임 시작 ! ');
+            // 스파이 랜덤 지정 후 게임 시작 전 emit.
+            const spyUser = await GameProvider.selectSpy(roomNum);
+            lobby.sockets.in(`/gameRoom${roomNum}`).emit('spyUser', spyUser);
 
-                if (nickname === spyUser) {
-                    socket.isSpy = 1;
-                }
+            if (nickname === spyUser) {
+                socket.isSpy = 1;
+            }
 
-                // 카테고리 및 제시어 랜덤 지정 후 게임 시작과 같이 emit.
-                const gameData = await GameProvider.giveWord(roomNum);
-                lobby.sockets.in(`/gameRoom${roomNum}`).emit('gameStart', gameData);
+            // 카테고리 및 제시어 랜덤 지정 후 게임 시작과 같이 emit.
+            const gameData = await GameProvider.giveWord(roomNum);
+            lobby.sockets.in(`/gameRoom${roomNum}`).emit('gameStart', gameData);
 
-                // 게임방 진행 활성화. 다른 유저 입장 제한.
-                await RoomProvider.getTrue(roomNum);
-                await redis.del(`ready${roomNum}`);
-                await redis.del(`readyStatus${roomNum}`);
-                await redis.del(`currentMember${roomNum}`);
-            }, 5000);
-
-            // 방의 timer id 저장.
-            await redis.set(`readyStatus${roomNum}`, readyStatus);
-        } else if (readyStatus !== '') {
-            // setTimeout 이 실행된 후 누군가 ready 를 취소했을 때 그 방의 setTimeout 정지시키기.
-            clearTimeout(readyStatus);
-            await redis.set(`readyStatus${roomNum}`, '');
+            // 게임방 진행 활성화. 다른 유저 입장 제한.
+            await RoomProvider.getTrue(roomNum);
+            await redis.del(`ready${roomNum}`);
+            await redis.del(`readyStatus${roomNum}`);
         }
     });
 });


### PR DESCRIPTION
# 수정 내용
### 1. `setTimeout` 삭제 및 `redis.del('currentMember${roomNum}')` 삭제
- 프론트에서 인원 체크해서 setTimeout을 사용하기로 해서 서버 쪽의 관련 코드 제거했습니다.
- 게임방이 진행된 상태로 바뀌면서 삭제하는 redis 내의 키값 중 `currentMember${roomNum}` 을 삭제하는 줄을 삭제했습니다. 다른 페이지에서도 계속 사용되기 때문에 게임이 완전히 끝난 후에 삭제해야합니다.
```javascript
if (currentCount === Number(readyCount) && currentCount > 3) {
            console.log('게임시작 5초전!');

            // 특정 방의 timer identifier 를 저장, 나중에 누군가가 ready 가 취소됬을 때 해당하는 timer id 를 찾아서 멈추기 위해.
            console.log('게임 시작 ! ');
            // 스파이 랜덤 지정 후 게임 시작 전 emit.
            const spyUser = await GameProvider.selectSpy(roomNum);
            lobby.sockets.in(`/gameRoom${roomNum}`).emit('spyUser', spyUser);

            if (nickname === spyUser) {
                socket.isSpy = 1;
            }

            // 카테고리 및 제시어 랜덤 지정 후 게임 시작과 같이 emit.
            const gameData = await GameProvider.giveWord(roomNum);
            lobby.sockets.in(`/gameRoom${roomNum}`).emit('gameStart', gameData);

            // 게임방 진행 활성화. 다른 유저 입장 제한.
            await RoomProvider.getTrue(roomNum);
            await redis.del(`ready${roomNum}`);
            await redis.del(`readyStatus${roomNum}`);
        }
```